### PR TITLE
Containerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.6.5-alpine3.7
+
+ENV HOME=/usr/src/app
+WORKDIR $HOME
+
+COPY . $HOME
+
+RUN apk --no-cache add build-base
+RUN pip install -r requirements.txt
+
+EXPOSE 6543
+CMD python app.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,15 @@ FROM python:3.6.5-slim
 ENV HOME=/usr/src/app
 WORKDIR $HOME
 
+COPY requirements.txt $HOME
+
+RUN apt-get update && \
+  apt-get -y install build-essential && \
+  rm -Rf /var/lib/apt/lists/* && \
+  pip install --no-cache-dir -r requirements.txt && \
+  apt-get -y purge build-essential
+
 COPY . $HOME
-
-RUN apt-get update && apt-get -y install build-essential && rm -Rf /var/lib/apt/lists/*
-
-RUN pip install -r requirements.txt
 
 EXPOSE 6543
 CMD python app.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.6.5-alpine3.7
+FROM python:3.6.5-slim
 
 ENV HOME=/usr/src/app
 WORKDIR $HOME
 
 COPY . $HOME
 
-RUN apk --no-cache add build-base
+RUN apt-get update && apt-get -y install build-essential && rm -Rf /var/lib/apt/lists/*
+
 RUN pip install -r requirements.txt
 
 EXPOSE 6543

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ push:
 	docker push $(IMAGE):latest
 
 rollout:
-	kubectl apply -f deploy.yml
+	gcloud container images describe $(IMAGE):$(TAG)
+	cat deploy.yml | sed 's/TAG/$(TAG)/g' | kubectl apply -f -
 	kubectl rollout status deployment/thesaurus-deployment
 
 deploy: build push rollout

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+CLUSTER?=thesaurus
+ZONE?=us-central1-a
+TAG?=$(shell git rev-parse --short HEAD)
+PROJECT?=thesaurus-207318
+IMAGE?=gcr.io/$(PROJECT)/thesaurus
+
+cluster:
+	gcloud container clusters create $(CLUSTER) \
+		--machine-type n1-standard-1 \
+		--num-nodes 1 \
+		--enable-autoscaling \
+		--min-nodes 1 \
+		--max-nodes 3 \
+		--zone $(ZONE) \
+		--project $(PROJECT)
+
+credentials:
+	gcloud auth configure-docker
+	gcloud container clusters get-credentials --project=$(PROJECT) --zone=$(ZONE) $(CLUSTER)
+
+build:
+	docker build -t $(IMAGE):latest -t $(IMAGE):$(TAG) .
+
+push:
+	docker push $(IMAGE):$(TAG)
+	docker push $(IMAGE):latest
+
+rollout:
+	kubectl apply -f deploy.yml
+	kubectl rollout status deployment/thesaurus-deployment
+
+deploy: build push rollout

--- a/deploy.yml
+++ b/deploy.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: thesaurus
-        image: gcr.io/thesaurus-207318/thesaurus
+        image: gcr.io/thesaurus-207318/thesaurus:TAG
         ports:
         - containerPort: 6543
 ---

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: thesaurus-deployment
+  labels:
+    app: thesaurus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: thesaurus
+  template:
+    metadata:
+      labels:
+        app: thesaurus
+    spec:
+      containers:
+      - name: thesaurus
+        image: gcr.io/thesaurus-207318/thesaurus
+        ports:
+        - containerPort: 6543
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: thesaurus-service
+  labels:
+    app: thesaurus
+spec:
+  type: LoadBalancer
+  selector:
+    app: thesaurus
+  ports:
+  - port: 80
+    targetPort: 6543

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+numpy
+scipy
 NearPy
 pyramid
 pyramid_jinja2

--- a/thesaurus/static/css/thesaurus.css
+++ b/thesaurus/static/css/thesaurus.css
@@ -1,4 +1,5 @@
 body {
+  background-color: orange;
   font-size: 1em;
   font-family: georgia,"times new roman",times,serif;
 }

--- a/thesaurus/static/css/thesaurus.css
+++ b/thesaurus/static/css/thesaurus.css
@@ -1,5 +1,4 @@
 body {
-  background-color: orange;
   font-size: 1em;
   font-family: georgia,"times new roman",times,serif;
 }


### PR DESCRIPTION
Adds a dockerfile (using `slim` rather than `alpine` since I had trouble getting numpy/scipy to work properly on alpine)

Adds a makefile with some common commands for using gcloud/kubernetes. There are variables at the top of the file defining various attributes of the cluster -- the cluster name, the project id, the image name. The commands:
* `make cluster` will create a cluster. After the first time, we won't be needing to use this directly, but this command captures some of the settings used to create the cluster
* `make credentials` will configure `gcloud` locally and needs to be run before other commands once
* `make build` will build a new docker container and tag it with the SHA of the current git commit
* `make push` will push the latest and currently tagged container
* `make rollout` will deploy the currently tagged container to the kubernetes cluster
* `make deploy` will run `build`, `push`, and then `deploy`

The `deploy.yml` describes the deployment and service that are running the app on the kubernetes cluster.

You can check out the details of the cluster on [Google Cloud Platform](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/thesaurus?project=thesaurus-207318&organizationId=278388076331&tab=details&persistent_volumes_tablesize=50&storage_class_tablesize=50&nodes_tablesize=50)