### PR TITLE
Deploy with gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get update && \
 COPY . $HOME
 
 EXPOSE 6543
-CMD gunicorn thesaurus.wsgi:application -b 0.0.0.0:6543
+CMD gunicorn thesaurus.wsgi:application --bind=0.0.0.0:6543 --timeout 120

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get update && \
 COPY . $HOME
 
 EXPOSE 6543
-CMD python app.py
+CMD gunicorn thesaurus.wsgi:application -b 0.0.0.0:6543

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ credentials:
 	gcloud container clusters get-credentials --project=$(PROJECT) --zone=$(ZONE) $(CLUSTER)
 
 build:
+	yarn build
 	docker build -t $(IMAGE):latest -t $(IMAGE):$(TAG) .
 
 push:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE?=gcr.io/$(PROJECT)/thesaurus
 
 cluster:
 	gcloud container clusters create $(CLUSTER) \
-		--machine-type n1-standard-1 \
+		--machine-type n1-highmem-2 \
 		--num-nodes 1 \
 		--enable-autoscaling \
 		--min-nodes 1 \

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,6 @@ rollout:
 	kubectl rollout status deployment/thesaurus-deployment
 
 deploy: build push rollout
+
+serve:
+	ENV=development python app.py

--- a/app.py
+++ b/app.py
@@ -1,47 +1,7 @@
-import os
-
 from wsgiref.simple_server import make_server
-from pyramid.config import Configurator
-
-# does this work? YEEESSSSSS
-settings = {
-    'pyramid.reload_assets': True,
-    'pyramid.reload_templates': True,
-}
-
-with Configurator(settings=settings) as config:
-    if os.getenv('ENV') == 'development':
-        config.include('pyramid_debugtoolbar')
-
-    config.include('pyramid_jinja2')
-    config.add_jinja2_renderer('.html')
-    config.add_jinja2_search_path("thesaurus:templates", name=".html")
-
-    # Thesaurus
-    config.add_route('nearest', '/')
-    config.add_route('analogy', '/analogy')
-    config.add_route('addition', '/addition')
-    config.add_route('average', '/average')
-    config.add_route('subtraction', '/subtraction')
-
-    # Codenames
-    config.add_route('codewords', '/codewords')
-    config.add_route('clue', '/clue')
-
-    # Serve our static files
-    prevent_http_cache = config.get_settings().get(
-        "pyramid.prevent_http_cache", False
-    )
-    config.add_static_view(
-        "static",
-        "thesaurus:static/",
-        cache_max_age=0 if prevent_http_cache else 10 * 365 * 24 * 60 * 60,
-    )
-
-    config.scan('thesaurus.views')
-    app = config.make_wsgi_app()
+from thesaurus.wsgi import application
 
 
 if __name__ == '__main__':
-    server = make_server('0.0.0.0', 6543, app)
+    server = make_server('0.0.0.0', 6543, application)
     server.serve_forever()

--- a/app.py
+++ b/app.py
@@ -1,42 +1,47 @@
+import os
+
 from wsgiref.simple_server import make_server
 from pyramid.config import Configurator
 
-if __name__ == '__main__':
-    # does this work? YEEESSSSSS
-    settings = {
-        'pyramid.reload_assets': True,
-        'pyramid.reload_templates': True,
-    }
+# does this work? YEEESSSSSS
+settings = {
+    'pyramid.reload_assets': True,
+    'pyramid.reload_templates': True,
+}
 
-    with Configurator(settings=settings) as config:
+with Configurator(settings=settings) as config:
+    if os.getenv('ENV') == 'development':
         config.include('pyramid_debugtoolbar')
 
-        config.include('pyramid_jinja2')
-        config.add_jinja2_renderer('.html')
-        config.add_jinja2_search_path("thesaurus:templates", name=".html")
+    config.include('pyramid_jinja2')
+    config.add_jinja2_renderer('.html')
+    config.add_jinja2_search_path("thesaurus:templates", name=".html")
 
-        # Thesaurus
-        config.add_route('nearest', '/')
-        config.add_route('analogy', '/analogy')
-        config.add_route('addition', '/addition')
-        config.add_route('average', '/average')
-        config.add_route('subtraction', '/subtraction')
+    # Thesaurus
+    config.add_route('nearest', '/')
+    config.add_route('analogy', '/analogy')
+    config.add_route('addition', '/addition')
+    config.add_route('average', '/average')
+    config.add_route('subtraction', '/subtraction')
 
-        # Codenames
-        config.add_route('codewords', '/codewords')
-        config.add_route('clue', '/clue')
+    # Codenames
+    config.add_route('codewords', '/codewords')
+    config.add_route('clue', '/clue')
 
-        # Serve our static files
-        prevent_http_cache = config.get_settings().get(
-            "pyramid.prevent_http_cache", False
-        )
-        config.add_static_view(
-            "static",
-            "thesaurus:static/",
-            cache_max_age=0 if prevent_http_cache else 10 * 365 * 24 * 60 * 60,
-        )
+    # Serve our static files
+    prevent_http_cache = config.get_settings().get(
+        "pyramid.prevent_http_cache", False
+    )
+    config.add_static_view(
+        "static",
+        "thesaurus:static/",
+        cache_max_age=0 if prevent_http_cache else 10 * 365 * 24 * 60 * 60,
+    )
 
-        config.scan('thesaurus.views')
-        app = config.make_wsgi_app()
+    config.scan('thesaurus.views')
+    app = config.make_wsgi_app()
+
+
+if __name__ == '__main__':
     server = make_server('0.0.0.0', 6543, app)
     server.serve_forever()

--- a/deploy.yml
+++ b/deploy.yml
@@ -26,7 +26,7 @@ spec:
           value: "glove.6B/glove.6B.300d.txt"
         resources:
           requests:
-            memory: "1500Mi"
+            memory: "2000Mi"
 ---
 
 kind: Service

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ NearPy
 pyramid
 pyramid_jinja2
 pyramid_debugtoolbar
+gunicorn

--- a/thesaurus/config.py
+++ b/thesaurus/config.py
@@ -1,0 +1,45 @@
+import os
+
+from wsgiref.simple_server import make_server
+from pyramid.config import Configurator
+
+def configure():
+# does this work? YEEESSSSSS
+    settings = {
+        'pyramid.reload_assets': True,
+        'pyramid.reload_templates': True,
+    }
+
+    with Configurator(settings=settings) as config:
+        if os.getenv('ENV') == 'development':
+            config.include('pyramid_debugtoolbar')
+
+        config.include('pyramid_jinja2')
+        config.add_jinja2_renderer('.html')
+        config.add_jinja2_search_path("thesaurus:templates", name=".html")
+
+        # Thesaurus
+        config.add_route('nearest', '/')
+        config.add_route('analogy', '/analogy')
+        config.add_route('addition', '/addition')
+        config.add_route('average', '/average')
+        config.add_route('subtraction', '/subtraction')
+
+        # Codenames
+        config.add_route('codewords', '/codewords')
+        config.add_route('clue', '/clue')
+
+        # Serve our static files
+        prevent_http_cache = config.get_settings().get(
+            "pyramid.prevent_http_cache", False
+        )
+        config.add_static_view(
+            "static",
+            "thesaurus:static/",
+            cache_max_age=0 if prevent_http_cache else 10 * 365 * 24 * 60 * 60,
+        )
+
+        config.scan('thesaurus.views')
+
+    return config
+

--- a/thesaurus/config.py
+++ b/thesaurus/config.py
@@ -3,15 +3,18 @@ import os
 from wsgiref.simple_server import make_server
 from pyramid.config import Configurator
 
+
+environment = os.getenv('ENV')
+
+
 def configure():
-# does this work? YEEESSSSSS
-    settings = {
-        'pyramid.reload_assets': True,
-        'pyramid.reload_templates': True,
-    }
+    settings = {}
+    if environment == 'development':
+        settings.setdefault("pyramid.reload_assets", True)
+        settings.setdefault("pyramid.reload_templates", True)
 
     with Configurator(settings=settings) as config:
-        if os.getenv('ENV') == 'development':
+        if environment == 'development':
             config.include('pyramid_debugtoolbar')
 
         config.include('pyramid_jinja2')

--- a/thesaurus/wsgi.py
+++ b/thesaurus/wsgi.py
@@ -1,0 +1,4 @@
+from thesaurus.config import configure
+
+
+application = configure().make_wsgi_app()


### PR DESCRIPTION
This includes a couple changes to make the deployed app work better:

* Upgraded the gcloud node from "standard" to "highmem"
* Bump up memory requirement for the container to 2gig
* Refactor the configuration/wsgi app creation to allow running it with `gunicorn`
* Bump up the worker timeout to 120 seconds (initially, `gunicorn` was terminating the worker after 30 seconds of inactivity while the worker was starting up. it takes longer than that to parse the GloVe data, so we'll be conservative and set it to 120 seconds)

The deployed app (http://104.198.213.88/) seemed to load faster now.